### PR TITLE
Fix typo in PIN_ROT_BTN ifdef

### DIFF
--- a/Software/src/Version 6/morsedefs.h
+++ b/Software/src/Version 6/morsedefs.h
@@ -116,7 +116,7 @@ const int PinDT=39;
 #endif
 
 /// encoder switch (BLACK knob)
-#ifdef PIN_ROT_CLK
+#ifdef PIN_ROT_BTN
 const int modeButtonPin = PIN_ROT_BTN;
 #else
 const int modeButtonPin = 37;


### PR DESCRIPTION
Change-Id: Ia0bc888af42e02b4017c79a67619fa65c3021a11

Fixes a simple typo in an #ifdef.