### PR TITLE
Add defines to make CDC Serial work on T190

### DIFF
--- a/Software/src/platformio.ini
+++ b/Software/src/platformio.ini
@@ -170,6 +170,8 @@ upload_speed = 921600
 board_upload.use_1200bps_touch = true
 
 build_flags =
+  -D ARDUINO_USB_MODE=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
   -D INTERNAL_PULLUP=1
   -D SKIP_BATTERY_PROTECT=1
   -D SKIP_LEGACY_PINDEFS=1


### PR DESCRIPTION
Change-Id: If847d14100ed76737c8d8ae6c23b5f1f8c3a094d

The Heltec T190 does not have the HW serial chip other ESP32 modules have.  Instead the ESP32 itself instantiates a CDC Serial USB interface.  This change adds the appropriate defines so the Arduino environment knows how to plumb the Serial class to the USB serial channel.